### PR TITLE
Simplify codepath for view instantiation

### DIFF
--- a/src/client/components/createroom/createroom.jade
+++ b/src/client/components/createroom/createroom.jade
@@ -1,7 +1,7 @@
 h1 Create Room
 
-if typeof error !== 'undefined'
-  p.error= error
+if typeof errorMessage !== 'undefined'
+  p.error= errorMessage
 
 p.
   From here you can create a room for the selected activity. This room will have

--- a/src/client/components/createroom/createroom.js
+++ b/src/client/components/createroom/createroom.js
@@ -19,6 +19,10 @@ define(function(require) {
       'submit form': 'submit'
     },
 
+    initialize: function(options) {
+      this.activities = options.activities;
+    },
+
     submit: function(ev) {
       ev.preventDefault();
       // Serialize the form into an object to send as JSON.
@@ -31,7 +35,7 @@ define(function(require) {
           Backbone.history.navigate('/room/' + data.id + '/', true);
         }, function(e) {
           // The error is a jQuery XHR object.
-          this.serialize.error = e.responseText;
+          this.errorMessage = e.responseText;
           this.render();
         });
       return false;
@@ -45,6 +49,13 @@ define(function(require) {
         contentType: 'application/json',
         dataType: 'json'
       }));
+    },
+
+    serialize: function() {
+      return {
+        activities: this.activities,
+        errorMessage: this.errorMessage
+      };
     }
   });
 

--- a/src/client/components/home/home.js
+++ b/src/client/components/home/home.js
@@ -5,7 +5,17 @@ define(function(require) {
   require('css!./home');
 
   var ActivityView = Layout.extend({
-    template: require('jade!./home')
+    template: require('jade!./home'),
+
+    initialize: function(options) {
+      this.activities = options.activities;
+    },
+
+    serialize: function() {
+      return {
+        activities: this.activities
+      };
+    }
   });
 
   return ActivityView;

--- a/src/client/scripts/router.js
+++ b/src/client/scripts/router.js
@@ -49,7 +49,7 @@ define(function(require) {
         if (self._loadId !== loadId) {
           return;
         }
-        self.setView(View, undefined, { group: group });
+        self.setView(View, { group: group });
       });
     },
 
@@ -73,7 +73,7 @@ define(function(require) {
         }
 
         var roomModel = new Backbone.Model({ id: room });
-        self.setView(ManageRoomView, undefined, { model: roomModel});
+        self.setView(ManageRoomView, { model: roomModel});
         self._loadId = loadId;
 
         when($.get('/api/room/' + room))
@@ -118,8 +118,10 @@ define(function(require) {
      * Synchronously initialize the specified view and insert it into the page.
      *
      * @param {View} View Backbone view constructor.
+     * @param {mixed} [options] Value to pass to the view constructor when
+     *                invoked.
      */
-    setView: function(View, data, options) {
+    setView: function(View, options) {
       if (this.currentView) {
         // Ignore navigation events to the same view--assume the view can
         // respond properly to such changes.
@@ -133,9 +135,6 @@ define(function(require) {
 
       this.currentView = new View(options || {});
       this.$el.append(this.currentView.$el);
-      if (data) {
-        this.currentView.serialize = data;
-      }
       this.currentView.render();
     }
   });


### PR DESCRIPTION
Hey @mzgoddard: I noticed this refactoring while reviewing #27, but it seemed a bit off-topic to mention at the time. Instead, I decided to wait until your work landed in `master` and then to demonstrate what I had in mind.

Basically, the "pattern" I set up for getting activity data to the top-level application's "Home" view was a little too informal/implicit. I was leveraging LayoutManager's `serialize` behavior to short-cut a more formal means to specify data for a view. Of course, it was only reasonable for you to follow suite, but this signature of `Router#setview`:

``` javascript
setView: function(View, data, options) {
```

...was a little messy. With this technique, each view is responsible for naming and managing its own data. Pay special attention to the inversion that took place in `ManageRoomView#addGroup`. This should be valid as long as the only change to the new data is in the `groups` attribute.

Commit message:

> Ensure that all views created by the application router are made in a
> consistent, straightforward way: via a constructor function and an
> optional first argument. Views that depend on this optional argument can
> then explicitly store/manipulate it as necessary.
