### PR TITLE
Improve server's ability to load shared code

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "lodash": "~2.4.1",
     "readable-stream": "^1.0.26-2",
     "socket.io": "~0.9.16",
-    "when": "~2.8.0"
+    "when": "~2.8.0",
+    "requirejs": "^2.1.11"
   },
   "devDependencies": {
     "chai": "~1.9.0",

--- a/src/activities/example/server/server.js
+++ b/src/activities/example/server/server.js
@@ -13,12 +13,14 @@ var CRUDManager = require('../../../server/crudmanager');
 var CRUDReplicator = require('../../../server/crudreplicator');
 var MemoryStore = require('../../../server/storememory');
 
-// The `shared/` directory is available for scripts that should be available on
-// both the client and the server. In order to consume AMD modules, server
-// scripts should use AMDefine's "intercept" module.
-// https://github.com/jrburke/amdefine
-require('amdefine/intercept');
-var sharedObject = require('../shared/object');
+// In order to consume AMD modules, server scripts should use a `requirejs`
+// function created by `common.createRequireJS`. This can be configured with an
+// AMD-compliant `paths` hash if the activity has any commonly-used scripts or
+// directories.
+var requirejs = common.createRequireJS({
+  shared: __dirname + '/../shared'
+});
+var sharedObject = requirejs('shared/object');
 sharedObject.random();
 
 // Create an express server.


### PR DESCRIPTION
AMDefine does not support AMD module resolution configuration, which is
used heavily in the browser environment. In order to mimic lookup
behavior, use the RequireJS library on the server and load the
application's AMD configuration prior to loading shared code.
