### PR TITLE
Remove unneeded define name in reportjson.js

### DIFF
--- a/src/client/components/reportjson/reportjson.js
+++ b/src/client/components/reportjson/reportjson.js
@@ -1,4 +1,4 @@
-define('components/reportjson/reportjson', function(require) {
+define(function(require) {
   'use strict';
 
   var $ = require('jquery');


### PR DESCRIPTION
Tested dev and production, reportjson does not need the name argument in define.
