### PR TITLE
Adjust activity icon size

### DIFF
--- a/src/client/components/home/home.css
+++ b/src/client/components/home/home.css
@@ -35,7 +35,7 @@
 
 .activity-icon {
   border: 10px solid #f2f2ee;
-  width: 100%;
+  width: 99%;
 }
 
 .activity-image {


### PR DESCRIPTION
This seems to solve the issue of icons overflowing on every browser that is not Chrome. That said, I'm not merging it without @ZeeJab's blessing. Addresses #84.
