### PR TITLE
Pizza Productivity: Correct error in instructions

### DIFF
--- a/src/activities/pizza/client/instructions.jade
+++ b/src/activities/pizza/client/instructions.jade
@@ -5,5 +5,5 @@
   ul.description-list
     li Only one player can work on one pizza at a given time.
     li You have to put the pizza back before you can switch stations.
-    li You have to build the pizza in the correct order: dough, sauce, cheese, pepperoni, and olives.
+    li You have to build the pizza in the correct order: dough, sauce, cheese, and olives.
     li A pizza must have all of the toppings listed above to be considered complete.


### PR DESCRIPTION
The Pizza Productivity activity was originally designed to include five
stages: "dough", "sauce", "cheese", "pepperoni", and "olives", and the
activity's instructions were written based on this design. In a later
iteration, the "pepperoni" stage was removed from the activity, but the
instructions were not updated accordingly.

Remove references to "pepperoni" from the activity instructions.

This should resolve gh-131