### PR TITLE
PPF: Improve drag-and-drop

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "require-jade": "~0.0.3",
     "requirejs": "~2.1.11",
     "requirejs-json": "~0.0.3",
-    "jquery.pep": "~0.5.12",
+    "jquery.pep": "~0.5.20",
     "when": "~2.8.0"
   }
 }

--- a/src/activities/ppf/client/components/main/main.js
+++ b/src/activities/ppf/client/components/main/main.js
@@ -16,7 +16,6 @@ define(function(require) {
     instructions: require('jade!./../../instructions')(),
 
     afterRender: function() {
-      var currentEl;
       var $slopeElems = this.$('.ppf-slope');
 
       // The jQuery.pep plugin dynamically infers the position of draggable
@@ -53,31 +52,14 @@ define(function(require) {
               bCenter.y > a.top && bCenter.y < a.bottom;
           },
 
-          /**
-           * Because jQuery.pep [1] does not invoke the `revertIf` method with
-           * any contextual data, the current drag target and drop target must
-           * be found with other mechanisms (the DOM must be queried for the
-           * drop target, and the drag target must be tracked using the
-           * plugin's `start` and `end` hooks.
-           *
-           * [1] http://pep.briangonzalez.org/
-           */
           revertIf: function() {
-            var currentSlope = $(currentEl).data('slope-val');
+            var currentSlope = this.$el.data('slope-val');
             var $target = $('.ppf-graph-target-active');
             var targetSlope = $target.data('slope-val');
 
             $target.removeClass('ppf-graph-target-active');
 
             return $target.length < 1 || currentSlope !== targetSlope;
-          },
-
-          start: function(event) {
-            currentEl = event.target;
-          },
-
-          end: function() {
-            currentEl = null;
           }
         });
     }


### PR DESCRIPTION
In order to determine if a given "drop" operation is valid (meaning the
element being dropped should retain its current position) or invalid
(meaning the element being dropped should revert to its original
location), the slop value must be read from the element being dragged.
Previously, the heuristic used to find the element being dragged would
not work if the drag event began with a `target` of a *child* of the
draggable element (i.e. the text label describing the slope value).

Use the context of the jQuery.pep `revertIf` method (which was not
previously defined [1]) to consistently reference the draggable element
(regardless of which element began the drag operation).

[1] This functionality was included in the 0.5.14 release of the jQuery
.pep library:

    > Set jQuery object as context of `revertIf` call
    >
    > This allows custom implementations of `revertIf` to reference the
    > current selection without relying on an externally-scoped
    > reference.

    https://github.com/briangonzalez/jquery.pep.js/commit/db160f02764b104e17e480ea1605191b22160dfc

This should resolve gh-132