### PR TITLE
Allow groups to be joined through the UI

### DIFF
--- a/src/activities/cocoa/client/components/main/main.js
+++ b/src/activities/cocoa/client/components/main/main.js
@@ -56,10 +56,9 @@ define(function(require) {
         }
       );
 
-      this._initConnection();
     },
 
-    _initConnection: function() {
+    initConnection: function() {
       cloak.configure({
 
         // Define custom messages sent by server to respond to.

--- a/src/activities/example/client/components/home/home.js
+++ b/src/activities/example/client/components/home/home.js
@@ -59,19 +59,21 @@ define(function(require) {
         }
       });
 
-      // Connect to socket
-      cloak.run(undefined, {
-        'socket.io': {
-          resource: 'activities/' + activitySlug + '/socket.io'
-        }
-      });
-
       // Set up chat input.
       this.chatInput = new ChatInputView();
       this.chatInput.on('chat', function(obj) {
         cloak.message('chat', obj);
       });
       this.setView('.input', this.chatInput.render());
+    },
+
+    initConnection: function() {
+      // Connect to socket
+      cloak.run(undefined, {
+        'socket.io': {
+          resource: 'activities/' + activitySlug + '/socket.io'
+        }
+      });
     },
 
     // Stop the network.

--- a/src/activities/pizza/client/components/main/main.js
+++ b/src/activities/pizza/client/components/main/main.js
@@ -34,7 +34,6 @@ define(function(require) {
 
     initialize: function() {
       this.gameState = new GameModel();
-      this.ready = this._initConnection();
 
       Backbone.sync = sync;
     },
@@ -72,7 +71,12 @@ define(function(require) {
     },
 
     setConfig: function() {
-      this.ready.then(_.bind(this.finishInit, this));
+      if (!('whenReady' in this)) {
+        throw new Error(
+          'Cannot set configuration before attempting to initialize connection'
+        );
+      }
+      this.whenReady.then(_.bind(this.finishInit, this));
     },
 
     // TODO: Re-name this method `handleRoundChange`, add a modal for when
@@ -87,8 +91,7 @@ define(function(require) {
       this.round.begin();
     },
 
-    _initConnection: function() {
-
+    initConnection: function() {
       var dfd = when.defer();
       var pizzas = this.gameState.get('pizzas');
       var players = this.gameState.get('players');
@@ -132,7 +135,7 @@ define(function(require) {
         }
       });
 
-      return dfd.promise;
+      this.whenReady = dfd.promise;
     },
 
     handleComplete: function() {

--- a/src/client/components/activity/activity.js
+++ b/src/client/components/activity/activity.js
@@ -47,7 +47,6 @@ define(function(require) {
     },
 
     constructor: function(options) {
-      var welcomeView;
 
       // When a child view define custom `events` hash, explicitly copy the
       // events defined by this view *into* the child (they would otherwise be
@@ -78,13 +77,49 @@ define(function(require) {
 
         this.setView('.activity-modals', joinGroupModal);
 
+        this.listenTo(joinGroupView, 'join', function(group) {
+          this.group = group;
+          this.welcome();
+          joinGroupModal.dismiss();
+        });
+
         joinGroupModal.summon({ mayDismiss: false });
 
         return;
       }
 
+      this.welcome();
+    },
+
+    /**
+     * Respond to user-defined runtime configuration as set in the "welcome"
+     * modal.
+     *
+     * @param {Object} config A hash reflecting the state of the from defined
+     *                 in the "welcome" modal (if any).
+     * @virtual
+     */
+    setConfig: function() {},
+
+    /**
+     * Initialize a realtime connection to the server. This method *must* be
+     * implemented by "room-based" (i.e. network-enabled) Activities.
+     *
+     * @virtual
+     */
+    initConnection: function() {
+      throw new Error(
+        'Room-based activities must define an `initConnection` method'
+      );
+    },
+
+    /**
+     * Set up the activity for game play, welcoming the user and (in the case
+     * of room-based activities) initializing a real-time connection.
+     */
+    welcome: function() {
       // Create a modal containing the activity's description and instructions.
-      welcomeView = new WelcomeView({
+      var welcomeView = new WelcomeView({
         title: this.config.title,
         image: this.config.image,
         description: this.description,
@@ -100,20 +135,14 @@ define(function(require) {
         this.welcomeModal.dismiss();
       });
 
+      if (this.config.roomBased) {
+        this.initConnection();
+      }
+
       this.setView('.activity-modals', this.welcomeModal);
 
       this.showWelcome();
     },
-
-    /**
-     * Respond to user-defined runtime configuration as set in the "welcome"
-     * modal.
-     *
-     * @param {Object} config A hash reflecting the state of the from defined
-     *                 in the "welcome" modal (if any).
-     * @virtual
-     */
-    setConfig: function() {},
 
     showWelcome: function() {
       this.welcomeModal.summon({ mayDismiss: this.hasBegun });

--- a/src/client/components/joingroup/joingroup.js
+++ b/src/client/components/joingroup/joingroup.js
@@ -64,13 +64,11 @@ define(function(require) {
               groupName + ' is a group for a different activity. It is a group for the ' + groupData.activity + ' activity.'
             );
           }
-          return groupData;
-        })
-        // All is good, navigate to the group.
-        .then(function() {
+
+          // All is good, navigate to the group.
+          self.trigger('join', groupName);
           Backbone.history.navigate(
-            '/activity/' + expectActivity  + '/group/' + groupName + '/',
-            true
+            '/activity/' + expectActivity  + '/group/' + groupName + '/'
           );
         })
         // Something went wrong, present the error.

--- a/src/client/scripts/router.js
+++ b/src/client/scripts/router.js
@@ -50,7 +50,7 @@ define(function(require) {
         if (self._loadId !== loadId) {
           return;
         }
-        self.setView(View, { group: group });
+        self.setView(View, { group: group, activitySlug: activity });
       });
     },
 


### PR DESCRIPTION
When a network-enabled Activity is visited without a specific group
name, the UI prompts the user for the name of an existing group. In
order to support this flow, the following changes are necessary:

- Properly initialize Activity views with the correct activity
  identifier string
- Formalize the definition of connection initialization logic for
  room-based activities, allowing it to be deferred in cases where the
  group name is not immediately available
- Close the modal dialog containing the `JoinGroup` view after the
  requested group has been verified by the server

This should resolve gh-128