### PR TITLE
Pizza Prod: Defer marking players as "ready"

### DIFF
--- a/src/activities/pizza/client/components/main/main.js
+++ b/src/activities/pizza/client/components/main/main.js
@@ -57,6 +57,8 @@ define(function(require) {
       this.listenTo(this.gameState, 'roundStart', this.handleRoundStart);
       this.listenTo(this.gameState, 'complete', this.handleComplete);
 
+      this.playerModel.set('isReady', true).save();
+
       // Update the layout according to the current game state
       if (!this.gameState.hasBegun()) {
         playerWait = new PlayerWait({

--- a/src/activities/pizza/client/components/player-wait/player-wait.js
+++ b/src/activities/pizza/client/components/player-wait/player-wait.js
@@ -12,12 +12,14 @@ define(function(require) {
     initialize: function(options) {
       this.gameState = options.gameState;
 
-      this.listenTo(this.gameState.get('players'), 'add remove', this.render);
+      this.listenTo(
+        this.gameState.get('players'), 'add change:isReady remove', this.render
+      );
     },
 
     serialize: function() {
       return {
-        playerCount: this.gameState.get('players').size(),
+        playerCount: this.gameState.countReadyPlayers(),
         MinPlayers: MinPlayers
       };
     }

--- a/src/activities/pizza/server/game-model.js
+++ b/src/activities/pizza/server/game-model.js
@@ -18,7 +18,7 @@ var ServerGameModel = GameModel.extend({
     this.pizzaID = 0;
 
     this.on('roundStart', this.handleRoundStart, this);
-    this.get('players').on('add', this.handleAddPlayer, this);
+    this.get('players').on('change:isReady', this.handleReadyPlayer, this);
 
     this.get('pizzas').on('change:foodState', function(pizza) {
       if (pizza.isComplete()) {
@@ -51,8 +51,8 @@ var ServerGameModel = GameModel.extend({
     this.save();
   },
 
-  handleAddPlayer: function() {
-    if (this.get('players').length < MinPlayers) {
+  handleReadyPlayer: function() {
+    if (this.countReadyPlayers() < MinPlayers) {
       return;
     }
     if (this.hasBegun()) {

--- a/src/activities/pizza/shared/game-model.js
+++ b/src/activities/pizza/shared/game-model.js
@@ -134,6 +134,17 @@ define(function(require) {
       }
 
       return ms;
+    },
+
+    /**
+     * Calculate the number of players who are ready to play.
+     *
+     * @return {Number}
+     */
+    countReadyPlayers: function() {
+      return this.get('players').reduce(function(count, player) {
+        return count + (player.get('isReady') ? 1 : 0);
+      }, 0);
     }
   });
 

--- a/src/activities/pizza/shared/player-model.js
+++ b/src/activities/pizza/shared/player-model.js
@@ -9,6 +9,7 @@ define(function(require) {
   var PlayerModel = Backbone.Model.extend({
     defaults: {
       workstation: null,
+      isReady: false,
       activatedRound: -1
     },
 


### PR DESCRIPTION
Introduce a new boolean attribute for players named `isReady`.
Initialize this attribute to `false`, and set to `true` when the player
dismisses the modal dialog containing the game instructions.

Update the server logic to wait for the requisite number of players to
be "ready" as defined above (instead of simply being present).

This change ensures that games do not begin until all players have had
an opportunity to read the instructions.

This resolves gh-130.