### PR TITLE
Print port on command line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ if (argv.activities) {
 
 createTop(argv, debug)
   .then(function(server) {
+    console.log('Server running on port ' + server.address().port);
     common.atTermination(server.close.bind(server), debug);
   })
   .catch(function(e) {


### PR DESCRIPTION
The server's port number is not always explicitly specified (it may be
assigned dynamically by the operating system or it may be set via
wrapper scripts). Print the port number to standard output in order to
make the port number easier to discover when the server is started from
the command line.

(example output)

    Running "server:hang" (server) task
       info  - socket.io started
    cloak running with express on port 49764
       info  - socket.io started
    cloak running with express on port 60210
    Top-level server running on port 8000
       info  - socket.io started
    cloak running with express on port 50136
