### PR TITLE
Update chart resizing logic

### DIFF
--- a/src/activities/income-and-taxes/client/components/main/main.js
+++ b/src/activities/income-and-taxes/client/components/main/main.js
@@ -36,7 +36,6 @@ define(function(require) {
       this._throttledResize = _.throttle(_.bind(this.resize, this, 500));
       $window.on('resize', this._throttledResize);
 
-      this.resize();
       this.drawChart();
 
       this.insertView('.it-controls', new Slider(_.extend({
@@ -69,11 +68,13 @@ define(function(require) {
     },
 
     resize: function() {
-      this.chart.width($window.width());
+      this.chart.width(this.$('.it-chart').width());
     },
 
     afterRender: function() {
       this.$('.it-chart').append(this.chart.base.node());
+
+      this.resize();
     },
 
     drawChart: function() {

--- a/src/activities/when-graphs-mislead/client/components/main/main.js
+++ b/src/activities/when-graphs-mislead/client/components/main/main.js
@@ -34,7 +34,6 @@ define(function(require) {
     return { y: 1 + ((current.y - previous.y) / previous.y), x: current.x };
   });
 
-  var $window = $(window);
   var yearFormat = d3.format('4');
 
   var tickFormatters = {
@@ -107,16 +106,17 @@ define(function(require) {
         this.chartState.fromUrl(fragmentData.get());
       }
 
-      this.resize();
       this.drawChart();
     },
 
     resize: function() {
-      this.chart.width($window.width() - 80);
+      this.chart.width(this.$('.wgdu-chart').width());
     },
 
     afterRender: function() {
       this.$('.wgdu-chart').append(this.chart.base.node());
+
+      this.resize();
     },
 
     drawChart: function() {

--- a/src/client/components/reportgrouphistogram/reportgrouphistogram.js
+++ b/src/client/components/reportgrouphistogram/reportgrouphistogram.js
@@ -85,9 +85,9 @@ define(function(require) {
     };
   };
 
-  var resetWidths = function(reports) {
+  var resetWidths = function(reports, width) {
     _.forEach(reports, function(report) {
-      report.barChart.width($window.width());
+      report.barChart.width(width);
     });
   };
 
@@ -100,10 +100,10 @@ define(function(require) {
       $body.append(report.$container);
     });
 
-    resetWidths(reports);
+    resetWidths(reports, $body.width());
 
     $window.on('resize', _.throttle(function() {
-      resetWidths(reports);
+      resetWidths(reports, $body.width());
     }, 300));
   });
 });


### PR DESCRIPTION
In the time since these charts were implemented, the surrounding layout
was modified to use only a percentage of the viewport's horizontal
space. This invalidated the underlying assumption--that the charts
should expand to the width of the viewport itself.

Calculate the chart width according to the containing element. This
contextual approach will automatically conform to any future changes to
the layout.

Defer initial width calculation until after the chart has been appended
to its container in order to avoid setting an invalid width.

Resolves gh-147