### PR TITLE
Pizza Prod: Fix endgame report chart

### DIFF
--- a/src/activities/income-and-taxes/client/components/main/main.js
+++ b/src/activities/income-and-taxes/client/components/main/main.js
@@ -26,7 +26,10 @@ define(function(require) {
       });
       this.setExtent();
 
-      chart.margin({ top: 10, right: 40, bottom: 25, left: 60 });
+      chart
+        .yAxisWidth(70)
+        .xAxisHeight(45)
+        .xAxisPadding(30);
       chart.height(300);
 
       this.chartState = new ChartState();

--- a/src/activities/pizza/client/components/report/report.js
+++ b/src/activities/pizza/client/components/report/report.js
@@ -21,7 +21,10 @@ define(function(require) {
 
       this.barChart.height(300);
       this.barChart.width(500);
-      this.barChart.margin({ top: 10, right: 40, bottom: 25, left: 60 });
+      this.barChart
+        .yAxisWidth(60)
+        .yAxisPadding(10)
+        .xAxisHeight(40);
       this.listenTo(WindowEmitter, 'resize', this.resize);
     },
 

--- a/src/activities/pizza/shared/game-model.js
+++ b/src/activities/pizza/shared/game-model.js
@@ -90,20 +90,12 @@ define(function(require) {
       var completedPizzasByRound = this.get('pizzas').completedByRound();
       var activePlayersByRound = this.get('activePlayerCounts').slice();
 
-      _.forEach(activePlayersByRound, function(roundPlayers, idx, allRounds) {
-        var alreadyActive = allRounds[idx - 1];
-
-        if (alreadyActive) {
-          allRounds[idx] += alreadyActive;
-        }
-      });
-
       return _.map(
           _.zip(activePlayersByRound, completedPizzasByRound),
           function(pair) {
             return {
               playerCount: pair[0],
-              pizzaCount: pair[1]
+              pizzaCount: pair[1] || 0
             };
           });
     },

--- a/src/activities/pizza/shared/pizza-collection.js
+++ b/src/activities/pizza/shared/pizza-collection.js
@@ -2,6 +2,7 @@ define(function(require) {
   'use strict';
 
   var Backbone = require('backbone');
+  var _ = require('lodash');
 
   var PizzaModel = require('./pizza-model');
 
@@ -20,16 +21,26 @@ define(function(require) {
       });
     },
 
+    /**
+     * Create an array describing the integer number of pizzas completed in
+     * each round. Each element of the array describes the number of pizzas for
+     * the round at that element's offset.
+     *
+     * For example, if the collection contains two pizzas that were completed
+     * in the second round and three pizzas created in the third round, this
+     * method would return the following array:
+     *
+     *     [0, 2, 3]
+     */
     completedByRound: function() {
       return this.chain()
-        .filter(function(pizza) {
-          return pizza.isComplete();
-        })
         .groupBy(function(pizza) {
           return pizza.get('activeRound');
         })
         .map(function(pizzas) {
-          return pizzas.length;
+          return _.filter(pizzas, function(pizza) {
+              return pizza.isComplete();
+            }).length;
         })
         .toArray()
         .value();

--- a/src/activities/when-graphs-mislead/client/components/main/main.js
+++ b/src/activities/when-graphs-mislead/client/components/main/main.js
@@ -54,8 +54,12 @@ define(function(require) {
       });
       var initialState;
 
-      chart.margin({ top: 10, right: 40, bottom: 25, left: 60 });
-      chart.height(300);
+      chart
+        .yAxisWidth(90)
+        .yAxisPadding(5)
+        .xAxisHeight(40)
+        .xAxisPadding(20)
+        .height(300);
       chart.xAxis.tickFormat(yearFormat);
 
       this.chartState = new ChartState();

--- a/src/client/components/bar-chart/bar-chart.js
+++ b/src/client/components/bar-chart/bar-chart.js
@@ -73,7 +73,7 @@ define(function(require) {
       // less than zero), artificially insert a zero into the set used to
       // calculate the Y domain.
       var withZero = [0].concat(data);
-      var xDomain = [-1 * padPct, data.length];
+      var xDomain = [-1 * padPct, data.length - padPct];
       var tickCount = data.length;
 
       if (this.omitZero) {

--- a/src/client/components/bar-chart/bar-chart.js
+++ b/src/client/components/bar-chart/bar-chart.js
@@ -5,7 +5,6 @@ define(function(require) {
   require('../base-chart/base-chart');
   require('css!./bar-chart');
 
-  var offset = 0;
   // Amount of a bar's maximum available horitontal space to use to draw the
   // bar.
   var widthPct = 0.5;
@@ -45,11 +44,11 @@ define(function(require) {
           merge: function() {
             var chart = this.chart();
             var omitZero = chart.omitZero ? 1 : 0;
-            var barWidth = chart.x(offset - padPct + widthPct + omitZero);
+            var barWidth = chart.x(widthPct + omitZero - padPct);
 
             this.attr('width', barWidth)
               .attr('x', function(d, i) {
-                return chart.x(i + offset) - (barWidth / 2);
+                return chart.x(i) - (barWidth / 2);
               });
           },
           'merge:transition': function() {
@@ -74,7 +73,7 @@ define(function(require) {
       // less than zero), artificially insert a zero into the set used to
       // calculate the Y domain.
       var withZero = [0].concat(data);
-      var xDomain = [offset - padPct, data.length + (offset * padPct)];
+      var xDomain = [-1 * padPct, data.length];
       var tickCount = data.length;
 
       if (this.omitZero) {

--- a/src/client/components/line-and-bubble-chart/line-and-bubble-chart.js
+++ b/src/client/components/line-and-bubble-chart/line-and-bubble-chart.js
@@ -33,10 +33,6 @@ define(function(require) {
 
       this.height(300);
       this.width(200);
-
-      this.yAxisLabel
-          .attr('transform', 'rotate(-90) translate(0,40)');
-
     },
 
     extent: function(data) {

--- a/src/client/components/reportgrouphistogram/reportgrouphistogram.js
+++ b/src/client/components/reportgrouphistogram/reportgrouphistogram.js
@@ -42,7 +42,10 @@ define(function(require) {
 
     barChart.height(300);
     barChart.width(500);
-    barChart.margin({ top: 10, right: 40, bottom: 25, left: 60 });
+    barChart
+      .yAxisWidth(60)
+      .yAxisPadding(10)
+      .xAxisHeight(35);
     barChart.extent(binned);
     barChart.draw(binned);
 

--- a/src/client/components/reporthistogram/reporthistogram.js
+++ b/src/client/components/reporthistogram/reporthistogram.js
@@ -28,7 +28,10 @@ define(function(require) {
 
   barChart.height(300);
   barChart.width(500);
-  barChart.margin({ top: 10, right: 40, bottom: 25, left: 60 });
+  barChart
+    .yAxisWidth(60)
+    .yAxisPadding(10)
+    .xAxisHeight(35);
 
   $(function() {
     $('#bar-chart').append(barChart.base.node());

--- a/test/unit/client/tests/activities/pizza/game-model.js
+++ b/test/unit/client/tests/activities/pizza/game-model.js
@@ -3,6 +3,8 @@ define(function(require) {
 
   var sinon = require('sinon');
 
+  var COMPLETED_STATE = 'olives';
+
   var GameModel = require('activities/pizza/shared/game-model');
 
   suite('Pizza Productivity: GameModel', function() {
@@ -74,6 +76,125 @@ define(function(require) {
 
         assert.equal(m.countReadyPlayers(), 6);
       });
+    });
+
+    suite('#report', function() {
+      function create(playerCounts, pizzas) {
+        var m = new GameModel({ activePlayerCounts: playerCounts });
+
+        m.get('pizzas').reset(pizzas);
+
+        return m;
+      }
+
+      test('zero pizzas', function() {
+        var m = create([1, 2, 2, 3], []);
+        var expected = [
+          { playerCount: 1, pizzaCount: 0 },
+          { playerCount: 2, pizzaCount: 0 },
+          { playerCount: 2, pizzaCount: 0 },
+          { playerCount: 3, pizzaCount: 0 }
+        ];
+
+        assert.deepEqual(expected, m.report());
+      });
+
+      test('zero pizzas (with absent players)', function() {
+        var m = create([1, 2, 0, 0], []);
+        var expected = [
+          { playerCount: 1, pizzaCount: 0 },
+          { playerCount: 2, pizzaCount: 0 },
+          { playerCount: 0, pizzaCount: 0 },
+          { playerCount: 0, pizzaCount: 0 }
+        ];
+
+        assert.deepEqual(expected, m.report());
+      });
+
+      test('zero pizzas completed', function() {
+        var m = create([1, 2, 2, 3], [
+            { activeRound: 1, foodState: null },
+            { activeRound: 2, foodState: null },
+            { activeRound: 2, foodState: null },
+            { activeRound: 3, foodState: null },
+            { activeRound: 3, foodState: null },
+            { activeRound: 3, foodState: null }
+          ]);
+        var expected = [
+          { playerCount: 1, pizzaCount: 0 },
+          { playerCount: 2, pizzaCount: 0 },
+          { playerCount: 2, pizzaCount: 0 },
+          { playerCount: 3, pizzaCount: 0 }
+        ];
+
+        assert.deepEqual(expected, m.report());
+      });
+
+      test('zero pizzas completed (with absent players)', function() {
+        var m = create([1, 2, 0, 0], [
+            { activeRound: 1, foodState: null },
+            { activeRound: 2, foodState: null },
+            { activeRound: 2, foodState: null },
+            { activeRound: 3, foodState: null },
+            { activeRound: 3, foodState: null },
+            { activeRound: 3, foodState: null }
+          ]);
+        var expected = [
+          { playerCount: 1, pizzaCount: 0 },
+          { playerCount: 2, pizzaCount: 0 },
+          { playerCount: 0, pizzaCount: 0 },
+          { playerCount: 0, pizzaCount: 0 }
+        ];
+
+        assert.deepEqual(expected, m.report());
+      });
+
+      test('all pizzas completed', function() {
+        var m = create([1, 2, 2, 3], [
+            { activeRound: 1, foodState: COMPLETED_STATE },
+            { activeRound: 2, foodState: COMPLETED_STATE },
+            { activeRound: 2, foodState: COMPLETED_STATE },
+            { activeRound: 3, foodState: COMPLETED_STATE },
+            { activeRound: 3, foodState: COMPLETED_STATE },
+            { activeRound: 3, foodState: COMPLETED_STATE },
+            { activeRound: 4, foodState: COMPLETED_STATE },
+            { activeRound: 4, foodState: COMPLETED_STATE },
+            { activeRound: 4, foodState: COMPLETED_STATE },
+            { activeRound: 4, foodState: COMPLETED_STATE }
+          ]);
+        var expected = [
+          { playerCount: 1, pizzaCount: 1 },
+          { playerCount: 2, pizzaCount: 2 },
+          { playerCount: 2, pizzaCount: 3 },
+          { playerCount: 3, pizzaCount: 4 }
+        ];
+
+        assert.deepEqual(expected, m.report());
+      });
+
+      test('some pizzas completed', function() {
+        var m = create([1, 2, 2, 3], [
+            { activeRound: 1, foodState: COMPLETED_STATE },
+            { activeRound: 2, foodState: COMPLETED_STATE },
+            { activeRound: 2, foodState: null },
+            { activeRound: 3, foodState: null },
+            { activeRound: 3, foodState: null },
+            { activeRound: 3, foodState: null },
+            { activeRound: 4, foodState: null },
+            { activeRound: 4, foodState: COMPLETED_STATE },
+            { activeRound: 4, foodState: COMPLETED_STATE },
+            { activeRound: 4, foodState: null }
+          ]);
+        var expected = [
+          { playerCount: 1, pizzaCount: 1 },
+          { playerCount: 2, pizzaCount: 1 },
+          { playerCount: 2, pizzaCount: 0 },
+          { playerCount: 3, pizzaCount: 2 }
+        ];
+
+        assert.deepEqual(expected, m.report());
+      });
+
     });
 
     suite('#timeRemaining', function() {

--- a/test/unit/client/tests/activities/pizza/pizza-collection.js
+++ b/test/unit/client/tests/activities/pizza/pizza-collection.js
@@ -56,5 +56,28 @@ define(function(require) {
       assert.deepEqual(_.pluck(c.complete(3), 'id'), [11, 14]);
       assert.deepEqual(_.pluck(c.complete(4), 'id'), []);
     });
+
+    test('#completedByRound', function() {
+      var c = new PizzaCollection([
+        { id: 1, activeRound: 0, foodState: null },
+        { id: 2, activeRound: 0, foodState: COMPLETED_STATE },
+        { id: 3, activeRound: 0, foodState: null },
+        { id: 4, activeRound: 1, foodState: null },
+        { id: 5, activeRound: 1, foodState: null },
+        { id: 6, activeRound: 1, foodState: null },
+        { id: 7, activeRound: 1, foodState: null },
+        { id: 8, activeRound: 2, foodState: COMPLETED_STATE },
+        { id: 9, activeRound: 2, foodState: COMPLETED_STATE },
+        { id: 10, activeRound: 2, foodState: COMPLETED_STATE },
+        { id: 11, activeRound: 3, foodState: COMPLETED_STATE },
+        { id: 12, activeRound: 3, foodState: null },
+        { id: 13, activeRound: 3, foodState: null },
+        { id: 14, activeRound: 3, foodState: COMPLETED_STATE },
+      ]);
+      var expected = [1, 0, 3, 2];
+
+
+      assert.deepEqual(c.completedByRound(), expected);
+    });
   });
 });


### PR DESCRIPTION
Resolving this issue actually involved two independent fixes to the report generation logic. Those changes are backed by unit tests, so hopefully that will help avoid regressions.

I chose to address the issue with axis labels by moving them outside of the chart field. This also avoids (unreported) issues where the data being visualized could collide with the axis labels themselves. Because this effects all instances of the project's generic bar chart, this change is also visible in the activity "instructor reports" for Pizza Productivity and The Supply and Demand of Cocoa.

As an example, here is a report for a game that had four total chefs and where 1 pizza was completed in the first round, 0 pizzas were completed in rounds 3 and 4, and 1 pizza was completed in the final round.

**Before**

![screenshot from 2015-12-08 13 15 53](https://cloud.githubusercontent.com/assets/677252/11664150/12a80418-9dae-11e5-8bfb-8aaa6e6891de.png)

**After**

![screenshot from 2015-12-08 13 16 10](https://cloud.githubusercontent.com/assets/677252/11664156/184add46-9dae-11e5-9919-d9d56015fb4b.png)

Resolves gh-142