### PR TITLE
Pizza Prod: Fix bug in player navigation

### DIFF
--- a/src/activities/pizza/server/game-model.js
+++ b/src/activities/pizza/server/game-model.js
@@ -18,6 +18,7 @@ var ServerGameModel = GameModel.extend({
     this.pizzaID = 0;
 
     this.on('roundStart', this.handleRoundStart, this);
+    this.on('roundEnd', this.handleRoundEnd, this);
     this.get('players').on('change:isReady', this.handleReadyPlayer, this);
 
     this.get('pizzas').on('change:foodState', function(pizza) {
@@ -110,6 +111,16 @@ var ServerGameModel = GameModel.extend({
     }
   },
 
+  /**
+   * Ensure that all pizzas ("active" or "inactive") are unassigned.
+   */
+  releasePizzas: function() {
+    this.get('pizzas')
+      .forEach(function(pizza) {
+        pizza.set('ownerID', null);
+      });
+  },
+
   handleRoundStart: function() {
     this.timeRemaining(RoundDuration);
 
@@ -117,6 +128,13 @@ var ServerGameModel = GameModel.extend({
     this.allocatePizzas();
 
     setTimeout(this.advance.bind(this), RoundDuration);
+  },
+
+  handleRoundEnd: function() {
+    // Release all pizzas at the termination of each round so that players who
+    // are in possession of a pizza as a round ends are able to navigate
+    // immediately at the onset of the following round.
+    this.releasePizzas();
   }
 });
 

--- a/src/activities/pizza/shared/game-model.js
+++ b/src/activities/pizza/shared/game-model.js
@@ -62,6 +62,10 @@ define(function(require) {
      * - 'complete': when transitioning out of the final round
      */
     handleRoundChange: function(model, roundNumber) {
+      if (roundNumber > 0) {
+        this.trigger('roundEnd', roundNumber - 1);
+      }
+
       if (this.isOver()) {
         this.trigger('complete');
       } else {


### PR DESCRIPTION
Clients are disallowed from navigating between workstations as long as
they are in possession of a pizza. Ensure that all pizzas ("active" or
"inactive") are unassigned at the termination of each round so that
players who are in possession of a pizza as a round ends are able to
navigate immediately at the onset of the following round.

Resolves gh-140