### PR TITLE
Add support for notifications (and one concreate notification)

### DIFF
--- a/src/activities/pizza/client/components/main/main.js
+++ b/src/activities/pizza/client/components/main/main.js
@@ -46,6 +46,10 @@ define(function(require) {
         pizzas: this.gameState.get('pizzas'),
         gameState: this.gameState
       });
+      this.listenTo(this.round, 'notification', function(data) {
+        this.trigger('notification', data);
+      });
+
       this.roundStart = new RoundStart({
         gameState: this.gameState,
         playerModel: this.playerModel,

--- a/src/activities/pizza/client/components/navigation/navigation.js
+++ b/src/activities/pizza/client/components/navigation/navigation.js
@@ -20,6 +20,13 @@ define(function(require) {
 
     navigate: function(event) {
       if (this.$el.hasClass('pizza-disabled')) {
+        this.trigger('notification', {
+          type: 'error',
+          title: 'Whoops!',
+          details:
+            'You can\'t switch workstations while you\'re working on a pizza.'
+        });
+
         return;
       }
       var direction = $(event.target).data('pizza-dir');

--- a/src/activities/pizza/client/components/round-start/round-start.css
+++ b/src/activities/pizza/client/components/round-start/round-start.css
@@ -1,0 +1,4 @@
+.pizza-round-start .activity-image {
+  width: 100px;
+  margin-right: 20px;
+}

--- a/src/activities/pizza/client/components/round-start/round-start.js
+++ b/src/activities/pizza/client/components/round-start/round-start.js
@@ -6,6 +6,8 @@ define(function(require) {
 
   var Modal = require('components/modal/modal');
 
+  require('css!./round-start');
+
   var RoundStart = Layout.extend({
     className: 'pizza-round-start',
     template: require('jade!./round-start'),

--- a/src/activities/pizza/client/components/round/round.js
+++ b/src/activities/pizza/client/components/round/round.js
@@ -43,6 +43,9 @@ define(function(require) {
       });
 
       this.navigation = new Navigation({ playerModel: this.playerModel });
+      this.listenTo(this.navigation, 'notification', function(data) {
+        this.trigger('notification', data);
+      });
 
       this.listenTo(this.pizzas, 'localOwnerTake', function(pizza) {
         this.workstation.setPizza(pizza);

--- a/src/client/components/activity/activity.css
+++ b/src/client/components/activity/activity.css
@@ -8,50 +8,8 @@
   background-color: #fff;
 }
 
-.activity-nav {
-  padding: 1em;
-  background-color: #62caae;
-}
-
-.activity-nav-container {
-  width: 90%;
-  max-width: 900px;
-  margin: auto;
-}
-
 .activity-nav .activity-home {
   font-size: 2rem;
-}
-
-.activity-title-light {
-  line-height: 1.6rem;
-  font-weight: 400;
-  color: white;
-  margin: 2rem 0;
-}
-
-.activity-help {
-  cursor: pointer;
-  background-color: white;
-  width: 35px;
-  height: 35px;
-  position: relative;
-  margin: 2rem 0;
-}
-
-.activity-help-icon {
-  position: absolute;
-  top: 5px;
-  left: 5px;
-  border-radius: 100%;
-  background-color: #eadd3f;
-  color: white;
-  font-weight: bold;
-  margin: 0;
-  font-size: 18px;
-  width: 25px;
-  height: 25px;
-  padding: 0px 10px;
 }
 
 .activity .activity-stage { min-height: 700px; }

--- a/src/client/components/activity/activity.jade
+++ b/src/client/components/activity/activity.jade
@@ -11,13 +11,7 @@ header
         li.menu-item
           a(href='http://genirevolution.org') Gen i Revolution
 
-.activity-nav.clearfix
-  .activity-nav-container
-    img(src=image).activity-image.left
-    h2.left.activity-title-light=title
-
-    .activity-help.right
-      p.activity-help-icon i
+.activity-overview-container
 
 .activity-stage.container
 

--- a/src/client/components/activity/activity.js
+++ b/src/client/components/activity/activity.js
@@ -7,6 +7,7 @@ define(function(require) {
   var JoinGroupView = require('components/joingroup/joingroup');
   var Modal = require('components/modal/modal');
   var WelcomeView = require('components/welcome/welcome');
+  var OverView = require('./overview');
   var formatters = require('scripts/formatters');
 
   require('css!./activity');
@@ -18,9 +19,6 @@ define(function(require) {
    */
   var ActivityView = Layout.extend({
     className: 'activity',
-    events: {
-      'click .activity-help': 'showWelcome'
-    },
     chromeTemplate: require('jade!./activity'),
 
     /**
@@ -35,10 +33,7 @@ define(function(require) {
     },
 
     template: function(data) {
-      var $markup = $('<div>').html(this.chromeTemplate({
-        title: this.config.title,
-        image: this.config.image
-      }));
+      var $markup = $('<div>').html(this.chromeTemplate());
 
       data.formatters = formatters;
       $markup.find('.activity-stage').html(this.homeTemplate(data));
@@ -48,6 +43,7 @@ define(function(require) {
 
     constructor: function(options) {
 
+      this.on('notification', this.showNotification);
       // When a child view define custom `events` hash, explicitly copy the
       // events defined by this view *into* the child (they would otherwise be
       // shadowed).
@@ -59,6 +55,10 @@ define(function(require) {
       this.group = options.group;
 
       Layout.prototype.constructor.apply(this, arguments);
+
+      this.overview = new OverView(this.config);
+      this.setView('.activity-overview-container', this.overview);
+      this.listenTo(this.overview, 'help', this.showWelcome);
 
       // Track when the activity has begun so the modal can be redrawn as
       // appropriate.
@@ -142,10 +142,15 @@ define(function(require) {
       this.setView('.activity-modals', this.welcomeModal);
 
       this.showWelcome();
+
     },
 
     showWelcome: function() {
       this.welcomeModal.summon({ mayDismiss: this.hasBegun });
+    },
+
+    showNotification: function(message) {
+      this.overview.notify(message);
     }
   });
 

--- a/src/client/components/activity/overview.css
+++ b/src/client/components/activity/overview.css
@@ -1,0 +1,148 @@
+.overview {
+  position: relative;
+  color: white;
+}
+
+.overview .title {
+  line-height: 1.6rem;
+  font-weight: 400;
+}
+
+.overview .overview-container {
+  width: 90%;
+  max-width: 900px;
+  margin: auto;
+}
+
+/**
+ * -------------
+ *    Header
+ * -------------
+ */
+.overview .help {
+  cursor: pointer;
+  width: 35px;
+  height: 35px;
+  position: relative;
+  margin: 2rem 0;
+}
+
+.overview .help-icon {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  border-radius: 100%;
+  background-color: #eadd3f;
+  font-weight: bold;
+  margin: 0;
+  font-size: 18px;
+  width: 25px;
+  height: 25px;
+  padding: 0px 10px;
+}
+
+
+.overview header {
+  padding: 1em;
+
+  background-color: #62caae;
+
+  transform: rotateX(0);
+  transform-origin: 0 100%;
+}
+
+.overview header .title {
+  margin: 1.3em 0;
+}
+
+.overview.notify header {
+  transform: rotateX(90deg);
+}
+
+.overview header .activity-image,
+.overview .notification .notif-icon {
+  width: 1em;
+  height: 1em;
+  margin-right: 0.2em;
+  font-size: 6.25em;
+}
+
+/**
+ * ------------------
+ *    Notification
+ * ------------------
+ */
+.overview .notification {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.overview header,
+.overview .notification {
+  transition: transform 0.3s, height 0s 0.3s;
+}
+
+.overview .notification {
+  padding: 1em;
+  margin: auto;
+
+  background-color: #ff8200;
+  color: #333;
+
+  /**
+   * The `height` attribute is set as a fallback mechanism for showing/hiding
+   * the notification. It is animated here so that the fallback does not
+   * interfere with the animation in modern browsers.
+   */
+  transform: rotateX(90deg);
+  transform-origin: 0 0;
+  height: 0;
+}
+
+.overview.notify .notification {
+  transition: transform 0.3s;
+  transform: rotateX(0);
+  height: 100%;
+}
+
+.overview .notif-icon {
+  display: inline-block;
+  border-width: 0.1em;
+
+  border-color: white;
+  border-radius: 1em;
+  border-style: solid;
+  color: white;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.overview .notif-glyph {
+  display: block;
+
+  font-size: 0.8em;
+  line-height: 1em;
+  font-weight: bold;
+}
+
+.overview .error .notif-icon {
+  color: white;
+  border-color: white;
+}
+
+.overview .notification .message {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.overview .notification .title {
+  margin: 0 0 0.3em;
+}
+
+.overview .notification p {
+  margin: 0;
+  font-size: 1.2em;
+}

--- a/src/client/components/activity/overview.jade
+++ b/src/client/components/activity/overview.jade
@@ -1,0 +1,24 @@
+header
+  .overview-container.clearfix
+    if image
+      img(src=image).activity-image.left
+    h2.left.title=title
+
+    .help.right
+      p.help-icon i
+
+.notification(class=message.type)
+  .overview-container
+    if message.type
+      span.notif-icon
+        span.notif-glyph
+          if message.type === 'error'
+            | !
+          else
+            | &#x2713;
+
+    .message
+      h2.title=message.title
+
+      if (message.details)
+        p=message.details

--- a/src/client/components/activity/overview.js
+++ b/src/client/components/activity/overview.js
@@ -1,0 +1,57 @@
+define(function(require) {
+  'use strict';
+  // Number of milliseconds during which a notification should be displayed
+  // before being dismissed.
+  var NOTIFICATION_LIFETIME = 4 * 1000;
+
+  var Layout = require('layoutmanager');
+
+  require('scripts/jquery.whenanimationend');
+
+  require('css!./overview');
+
+  return Layout.extend({
+    className: 'overview',
+    template: require('jade!./overview'),
+    events: {
+      'click .help': 'requestHelp'
+    },
+
+    initialize: function(options) {
+      this.title = options.title;
+      this.image = options.image;
+    },
+
+    notify: function(message) {
+      this.message = message;
+      this.render();
+
+      // Wait until the next turn of the event loop before adding the class in
+      // order to properly trigger CSS transitions on the newly-rendered
+      // elements.
+      setTimeout(function() {
+        this.$el.addClass('notify');
+
+        setTimeout(this.dismissNotification.bind(this), NOTIFICATION_LIFETIME);
+      }.bind(this), 0);
+
+      return this;
+    },
+
+    dismissNotification: function() {
+      this.$el.removeClass('notify');
+    },
+
+    requestHelp: function() {
+      this.trigger('help');
+    },
+
+    serialize: function() {
+      return {
+        title: this.title,
+        image: this.image,
+        message: this.message || {}
+      };
+    }
+  });
+});

--- a/src/client/components/home/home.css
+++ b/src/client/components/home/home.css
@@ -38,11 +38,6 @@
   width: 99%;
 }
 
-.activity-image {
-  width: 100px;
-  margin-right: 20px;
-}
-
 .home-activity-list {
   list-style-type: none;
   text-align: center;

--- a/src/client/components/welcome/welcome.css
+++ b/src/client/components/welcome/welcome.css
@@ -2,3 +2,7 @@
   font-size: 0.9rem;
 }
 
+.welcome .activity-image {
+  width: 100px;
+  margin-right: 20px;
+}


### PR DESCRIPTION
Players cannot move between workstations when they are in possession of a pizza. Issue an activity-level notification to the user when they attempt to navigate under these circumstances.

@cbujara The bulk of the work required for this is in the first commit, but those changes have no perceptible effect on the UI. At least, they shouldn't--please let me know if you see any changes *other* than the new notification in the Pizza Productivity application.

I improved the look-and-feel from my initial proposal in gh-62. Because the proposed notification obscured the navigation header, I decided to "go all the way" and more fully integrate it into the header itself:

![notification-demo-b](https://cloud.githubusercontent.com/assets/677252/11757325/586b5d88-a02e-11e5-8112-d0465e62f7f0.gif)

I think this is cleaner because it results in fewer visual regions. One potential drawback is it tends to preclude displaying multiple notifications *simultaneously*. I haven't seen a use case for that, so I personally think it's safe to stick with this UI for now.

Resolves gh-62