### PR TITLE
Re-enable "Add Group" button

### DIFF
--- a/src/client/components/manageroom/manageroom.jade
+++ b/src/client/components/manageroom/manageroom.jade
@@ -41,7 +41,7 @@
           a(href='/#/group/' + group.name + '/')= location.protocol + '//' + location.host + '/group/' + group.name + '/'
 
     .controls
-      a.button(href='javascript:;') Add Group
+      a.js-add-group.button(href='javascript:;') Add Group
 
       a.button(href='/activities/' + activity + '/report/' + room + '/download').
         Download Report

--- a/src/client/components/manageroom/manageroom.js
+++ b/src/client/components/manageroom/manageroom.js
@@ -18,7 +18,7 @@ define(function(require) {
       title: 'Manage Room'
     },
     events: {
-      'click .add-group': 'addGroup',
+      'click .js-add-group': 'addGroup',
     },
 
     initialize: function() {


### PR DESCRIPTION
In modifying the application interface, commit 8a792822e0855be8c45fbeddeef73432d07b8e8a modified the CSS class list of the "Add Group" element. In removing a class name required by the JavaScript logic (though unused by any stylesheet), this change disabled the "click" functionality of the "Add Group" element.

Re-enable the functionality, changing the class name to more explicitly convey the intended use.

Resolves gh-138