### PR TITLE
Pizza Prod: Fix "queue pizza" placement issues

### DIFF
--- a/src/activities/pizza/client/components/queue-pizza/queue-pizza.js
+++ b/src/activities/pizza/client/components/queue-pizza/queue-pizza.js
@@ -70,6 +70,12 @@ define(function(require) {
       this.$el.removeAttr('style');
       this.$el.pep({
         deferPlacement: true,
+        // Dragging removes the element from the document flow; alert the
+        // parent view of this event so it may take any precautions necessary
+        // to preserve layout geometry.
+        initiate: _.bind(function() {
+          this.trigger('startDrag');
+        }, this),
         revert: true,
         shouldEase: false,
         revertIf: this.revertIf,

--- a/src/activities/pizza/client/components/queue/queue.css
+++ b/src/activities/pizza/client/components/queue/queue.css
@@ -10,11 +10,18 @@
 }
 
 .pizza-queue-pizza-container {
+  position: relative;
 
   display: inline-block;
 }
 .pizza-queue-pizza-container.pizza-taken .pizza-queue-pizza {
-  display: none;
+  /**
+   * Pizzas that are taken should not be visible within the queue, but the
+   * space they would normally occupy should be reserved. This allows all other
+   * pizzas to maintain a consistent position across these changes of
+   * ownership.
+   */
+  visibility: hidden;
 }
 .pizza-queue-pizza-container.pizza-ready {
   animation-name: pizza-ready-glow;

--- a/src/activities/pizza/client/components/queue/queue.js
+++ b/src/activities/pizza/client/components/queue/queue.js
@@ -33,7 +33,19 @@ define(function(require) {
         model: model,
         playerModel: this.playerModel
       });
-      this.insertView('[data-pizza-id="' + model.get('id') + '"]', view);
+      var containerSelector = '[data-pizza-id="' + model.get('id') + '"]';
+
+      // During drag operations, the "queue pizza" elements are removed from
+      // the document flow and positioned absolutely. Explicitly set the
+      // dimensions of the containing element at that time so the queue does
+      // not "collapse."
+      this.listenTo(view, 'startDrag', function() {
+        var $container = this.$(containerSelector);
+        $container.height(view.$el.height());
+        $container.width(view.$el.width());
+      });
+
+      this.insertView(containerSelector, view);
     },
 
     removePizza: function(model) {
@@ -41,10 +53,8 @@ define(function(require) {
       this.render();
     },
 
-    handleTake: function(pizza) {
+    handleTake: function() {
       this.toggleDraggables(false);
-      this.getView('[data-pizza-id="' + pizza.get('id') + '"]')
-        .$el.hide();
     },
 
     handleDrop: function() {


### PR DESCRIPTION
Ensure that when "queue pizzas" are removed from the queue, their
position on the space is reserved (avoiding visual shifting of the
remaining pizzas).

In some circumstances (e.g. when one player takes and releases a pizza
while another player is dragging it), "queue pizzas" would not revert to
their correct location. This change also corrects the placement in that
case.