### PR TITLE
Pizza Prod: Pad value in countdown timer

### DIFF
--- a/src/activities/pizza/client/components/progress/progress.css
+++ b/src/activities/pizza/client/components/progress/progress.css
@@ -13,6 +13,7 @@
 }
 
 .pizza-counter-count-time {
+  display: block;
   background-color: white;
   width: 90px;
   height: 60px;

--- a/src/activities/pizza/client/components/progress/progress.jade
+++ b/src/activities/pizza/client/components/progress/progress.jade
@@ -1,8 +1,19 @@
+mixin padLeft(value, width)
+  - var numZeros = Math.max(0, width - value.toFixed().length);
+  - var zeros = new Array(numZeros + 1).join('0')
+  = zeros + value
+
+mixin duration(ms, classNames)
+  //- The `datetime` attribute recognizes durations specified via the "P"
+  //- prefix http://www.w3.org/TR/html-markup/time.html
+  time(class=classNames, datetime='PT' + Math.floor(ms / 1000) + 'S')
+    span.minutes= Math.floor(ms / (60 * 1000))
+    span.seconds
+      +padLeft(Math.floor(ms / 1000) % 60, 2)
+
 .pizza-counter
   .pizza-counter-count-time= completeCount
   label.count-time-label Completed
 .pizza-time
-  div.pizza-counter-count-time
-    span.minutes= Math.floor(timeRemaining / (60 * 1000))
-    span.seconds= Math.floor(timeRemaining / 1000) % 60
+  +duration(timeRemaining, ['pizza-counter-count-time'])
   label.count-time-label Time Left


### PR DESCRIPTION
Consistently render the number of seconds remaining with two digits
(padding with zeros for values less than 10), emulating traditional
digital clock faces.