### PR TITLE
Pizza Productivity: Add error notification

### DIFF
--- a/src/activities/pizza/client/components/queue/queue.js
+++ b/src/activities/pizza/client/components/queue/queue.js
@@ -45,6 +45,10 @@ define(function(require) {
         $container.width(view.$el.width());
       });
 
+      this.listenTo(view, 'notification', function(data) {
+        this.trigger('notification', data);
+      });
+
       this.insertView(containerSelector, view);
     },
 

--- a/src/activities/pizza/client/components/round/round.js
+++ b/src/activities/pizza/client/components/round/round.js
@@ -46,6 +46,9 @@ define(function(require) {
       this.listenTo(this.navigation, 'notification', function(data) {
         this.trigger('notification', data);
       });
+      this.listenTo(this.queue, 'notification', function(data) {
+        this.trigger('notification', data);
+      });
 
       this.listenTo(this.pizzas, 'localOwnerTake', function(pizza) {
         this.workstation.setPizza(pizza);


### PR DESCRIPTION
When the player attempts to place a pizza in an incompatible
workstation, issue a notification message explaining why the pizza has
been returned to the queue.

@cbujara The notification reads:

> #### Whoops!
>
> You can\'t work on that pizza in this workstation

Does that sound good to you?

Resolves gh-62