### PR TITLE
Extend Modal to support in small viewports

### DIFF
--- a/src/client/components/modal/modal.css
+++ b/src/client/components/modal/modal.css
@@ -5,6 +5,8 @@
   bottom: 0;
   left: 0;
   z-index: 4;
+
+  overflow-y: auto;
 }
 
 .modal .screen {
@@ -18,22 +20,12 @@
   opacity: 0.7;
 }
 
-.modal .center {
-  position: relative;
-  left: 50%;
-
-  width: 0;
-}
-
 .modal .surface {
-  position: absolute;
-  left: -21rem;
-  top: 4rem;
+  position: relative;
 
+  margin: 4rem auto 0 auto;
   width: 40rem;
-
-  /*overflow-y: scroll;*/
-  /*max-height: 300px;*/
+  max-width: 100%;
 
   background-color: #FFF;
   box-shadow: 0 0 10px #666;
@@ -87,20 +79,20 @@
 
 .modal .dismiss {
   position: absolute;
+  top: 0;
+  right: 0;
 
-  top: -2.75rem;
-  right: -2.75rem;
-
-  border: 3px solid white;
-  border-radius: 50%;
-  background: none;
-
-  cursor: pointer;
-  font-weight: bold;
-  font-size: 15px;
-
-  color: white;
   padding: 0 6px;
+  border-width: 3px;
+
+  background: none;
+  border-color: #333;
+  border-radius: 50%;
+  border-style: solid;
+  color: #333;
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: bold;
 }
 
 .modal .help-icon { margin-right: 10px; }

--- a/src/client/components/modal/modal.jade
+++ b/src/client/components/modal/modal.jade
@@ -1,7 +1,6 @@
 .screen
 
-.center
-  .surface
-    .content
-    if mayDismiss
-      button.dismiss &times;
+.surface
+  .content
+  if mayDismiss
+    button.dismiss &times;


### PR DESCRIPTION
Improve support for modal dialog boxes in small (e.g. mobile) viewports:

- Ensure that dialogs never extend beyond the left-most and right-most
  boundaries of the viewport
- Enable vertical scrolling in cases where the dialogs' content extend
  beyond the bottom of the viewport
- Reposition the "dismiss" button to fall within the dialog's content
  area

@cbujara As we discussed on today's call, this partially addresses gh-143, specifically:

> unable to resize/close instructions displayed on launch.

...but more work is necessary before we can call the "Supply and Demand of Cocoa" application "mobile friendly".